### PR TITLE
Latest firmware for some lights will not accept negative "id"

### DIFF
--- a/yeelight/lib/yee.js
+++ b/yeelight/lib/yee.js
@@ -93,7 +93,7 @@ YeeDevice = function (did, loc, model, power, bri, hue, sat, ct, name, cb) {
             console.log("send hb to: " + that.did);
 
             that.sendCmd({
-                id: -1,
+                id: 1,
                 method: 'get_prop',
                 params: ['power', 'bright', 'rgb']
             });
@@ -107,7 +107,7 @@ YeeDevice = function (did, loc, model, power, bri, hue, sat, ct, name, cb) {
             rsps.forEach(function (json, idex, array) {
                 try {
                     JSON.parse(json, function(k,v) {
-                       if (k == 'id' && v == -1) {
+                       if (k == 'id' && v == 1) {
                            that.hb_lost = 0;
                        }
 


### PR DESCRIPTION
After testing on model "ceiling1" and "ceiling3" with latest firmware (2.0.2_0192 and 2.0.2_0048). I've found out LAN control no longer accept command with "id" being negative value. They will return "invalid command" therefore causing the plugin to spit out "heartbeat lost" and kept trying to reconnect.

More info: https://forum.yeelight.com/t/topic/17595 (Chinese)

HomeBridge Log：
> closed the socket and retry
> [4/26/2020, 2:42:15 AM] [homebridge-yeelight.yeelight] failed to connect!
> [4/26/2020, 2:42:15 AM] [homebridge-yeelight.yeelight] accesseory unreachable
> [4/26/2020, 2:42:15 AM] [homebridge-yeelight.yeelight] dev disconnected 0x0000000007cd839e false
> retry connect (18) ...: 0x0000000007cd839e
> heartbeat lost, close socket and reconnect
> closed the socket and retry
> [4/26/2020, 2:42:25 AM] [homebridge-yeelight.yeelight] failed to connect!
> [4/26/2020, 2:42:25 AM] [homebridge-yeelight.yeelight] accesseory unreachable
> [4/26/2020, 2:42:25 AM] [homebridge-yeelight.yeelight] dev disconnected 0x0000000007cd839e false
> retry connect (19) ...: 0x0000000007cd839e
> heartbeat lost, close socket and reconnect
> closed the socket and retry
> [4/26/2020, 2:42:35 AM] [homebridge-yeelight.yeelight] failed to connect!
> [4/26/2020, 2:42:35 AM] [homebridge-yeelight.yeelight] accesseory unreachable
> [4/26/2020, 2:42:35 AM] [homebridge-yeelight.yeelight] dev disconnected 0x0000000007cd839e false
> retry connect (20) ...: 0x0000000007cd839e

Some testing result using Yeelight python demo:
> Enter a command: c 1 {"id":-1,"method":"get_prop","params":["power"]}
> connect 10.0.2.63 55443 ... 
> {"id":-1,"method":"get_prop","params":["power"]}
> {"id":0, "error":{"code":-1, "message":"invalid command"}}
> 
> Enter a command: c 1 {"id":1,"method":"get_prop","params":["power"]}
> connect 10.0.2.63 55443 ...
> {"id":1,"method":"get_prop","params":["power"]}
> {"id":1,"result":["on"]}